### PR TITLE
The google gce comes with both python 2.7 and 3.6

### DIFF
--- a/install_gce.sh
+++ b/install_gce.sh
@@ -5,7 +5,7 @@ git clone https://github.com/salesforce/ctrl.git
 mv ctrl/* .
 
 # Cython is needed to compile fastBPE
-sudo pip install Cython
+sudo python -m pip install Cython
 
 # Patch the TensorFlow estimator package
 FILE="/usr/local/lib/python2.7/dist-packages/tensorflow_estimator/python/estimator/keras.py"


### PR DESCRIPTION
The pip by default is for python 3 but the salesforce ctrl needs python 2.7
Need to specify which version of python for pip to use to install cython before installing fastBPE
sudo python -m pip install Cython